### PR TITLE
Add Manifest-v*.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+Manifest-v*.toml


### PR DESCRIPTION
## Summary
- Adds `Manifest-v*.toml` glob pattern to `.gitignore` to exclude version-specific manifest files from the repository.

## Test plan
- [ ] Verify `.gitignore` correctly excludes manifest files

🤖 Generated with [Claude Code](https://claude.com/claude-code)